### PR TITLE
Fix Create Resource Type ID

### DIFF
--- a/helper/resources.go
+++ b/helper/resources.go
@@ -18,6 +18,7 @@ func CreateResource(ctx context.Context, c *api.Client, folderParentID, name, us
 	for _, tmp := range types {
 		if tmp.Slug == "password-and-description" {
 			rType = &tmp
+			break
 		}
 	}
 	if rType == nil {


### PR DESCRIPTION
Fix determining the id for the resource type password-and-description.

https://github.com/passbolt/go-passbolt-cli/issues/32